### PR TITLE
Refactor marketing site into single-page landing with charts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,5 @@
+- Converted marketing pages into single landing page with anchor sections in `Home.tsx`.
+- Added chart components (`KpiLineChart`, `KpiBarChart`, `KpiDonut`) with demo datasets and modal integration.
+- Updated router in `App.tsx` to redirect legacy marketing routes to anchors.
+- Revised marketing layout with sticky header and anchor navigation.
+- Added light theme variables and smooth scrolling enhancements in `index.css`.

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -8,11 +8,6 @@ import { AuthProvider } from "@/components/providers/auth-provider";
 
 // Marketing Pages
 import Home from "./pages/Home";
-import Product from "./pages/Product";
-import Why from "./pages/Why";
-import UseCases from "./pages/UseCases";
-import Pricing from "./pages/Pricing";
-import Contact from "./pages/Contact";
 import NotFound from "./pages/NotFound";
 
 // Auth Pages
@@ -58,11 +53,11 @@ const App = () => (
             <Routes>
               {/* Marketing Routes */}
               <Route path="/" element={<Home />} />
-              <Route path="/product" element={<Product />} />
-              <Route path="/why" element={<Why />} />
-              <Route path="/use-cases" element={<UseCases />} />
-              <Route path="/pricing" element={<Pricing />} />
-              <Route path="/contact" element={<Contact />} />
+              <Route path="/product" element={<Navigate to="/#product" replace />} />
+              <Route path="/why" element={<Navigate to="/#why" replace />} />
+              <Route path="/use-cases" element={<Navigate to="/#use-cases" replace />} />
+              <Route path="/pricing" element={<Navigate to="/#pricing" replace />} />
+              <Route path="/contact" element={<Navigate to="/#faq-feedback" replace />} />
               
               {/* Auth Routes */}
               <Route path="/auth/login" element={<AuthLogin />} />

--- a/apps/app/src/components/charts/KpiBarChart.tsx
+++ b/apps/app/src/components/charts/KpiBarChart.tsx
@@ -1,0 +1,15 @@
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts'
+import { dataDsar } from './data'
+
+export default function KpiBarChart() {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={dataDsar} margin={{ left: 12, right: 12 }}>
+        <XAxis dataKey="type" tickLine={false} axisLine={false} className="text-xs" />
+        <YAxis tickLine={false} axisLine={false} className="text-xs" />
+        <Tooltip cursor={{ fill: 'hsl(var(--muted))' }} />
+        <Bar dataKey="days" fill="hsl(var(--primary))" radius={4} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/apps/app/src/components/charts/KpiDonut.tsx
+++ b/apps/app/src/components/charts/KpiDonut.tsx
@@ -1,0 +1,31 @@
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { dataAnomaly } from './data'
+
+const COLORS = [
+  'hsl(var(--primary))',
+  'hsl(var(--accent))',
+  'hsl(var(--muted-foreground))',
+  'hsl(var(--ring))'
+]
+
+export default function KpiDonut() {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart>
+        <Pie
+          data={dataAnomaly}
+          dataKey="value"
+          nameKey="name"
+          innerRadius={60}
+          outerRadius={100}
+          paddingAngle={2}
+        >
+          {dataAnomaly.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip />
+      </PieChart>
+    </ResponsiveContainer>
+  )
+}

--- a/apps/app/src/components/charts/KpiLineChart.tsx
+++ b/apps/app/src/components/charts/KpiLineChart.tsx
@@ -1,0 +1,15 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts'
+import { dataLogins } from './data'
+
+export default function KpiLineChart() {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={dataLogins} margin={{ left: 12, right: 12 }}>
+        <XAxis dataKey="day" tickLine={false} axisLine={false} className="text-xs" />
+        <YAxis tickLine={false} axisLine={false} className="text-xs" />
+        <Tooltip cursor={{ fill: 'hsl(var(--muted))' }} />
+        <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" strokeWidth={2} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/apps/app/src/components/charts/data.ts
+++ b/apps/app/src/components/charts/data.ts
@@ -1,0 +1,22 @@
+// logins per day (letzte 14 Tage)
+export const dataLogins = [
+  { day: 'Mo', value: 120 }, { day: 'Di', value: 150 }, { day: 'Mi', value: 180 },
+  { day: 'Do', value: 160 }, { day: 'Fr', value: 210 }, { day: 'Sa', value: 90 }, { day: 'So', value: 70 },
+  { day: 'Mo2', value: 140 }, { day: 'Di2', value: 170 }, { day: 'Mi2', value: 200 },
+  { day: 'Do2', value: 190 }, { day: 'Fr2', value: 230 }, { day: 'Sa2', value: 110 }, { day: 'So2', value: 80 },
+];
+
+// DSAR-Durchlaufzeiten (in Tagen)
+export const dataDsar = [
+  { type: 'Auskunft', days: 3.2 },
+  { type: 'Löschung', days: 2.1 },
+  { type: 'Berichtigung', days: 1.4 },
+];
+
+// Anomalie-Kategorien
+export const dataAnomaly = [
+  { name: 'Fehlversuche', value: 42 },
+  { name: 'Ungewöhnl. Orte', value: 18 },
+  { name: 'Ungewöhnl. Zeiten', value: 25 },
+  { name: 'Sonstiges', value: 15 },
+];

--- a/apps/app/src/components/marketing-layout.tsx
+++ b/apps/app/src/components/marketing-layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import ThemeToggle from '@/components/ui/theme-toggle'
 import { useAuthContext } from '@/components/providers/auth-provider'
@@ -11,15 +11,15 @@ export default function MarketingLayout({ children }: Props) {
   const { isAuthenticated } = useAuthContext()
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="border-b">
+      <header className="sticky top-0 z-50 backdrop-blur bg-background/80 border-b">
         <div className="container flex h-16 items-center justify-between">
-          <div className="font-bold text-xl">OptiSentry</div>
+          <a href="#top" className="font-bold text-xl cursor-pointer">OptiSentry</a>
           <nav className="flex items-center space-x-2">
-            <Link to="/product" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Produkt</Link>
-            <Link to="/why" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Warum OptiSentry</Link>
-            <Link to="/use-cases" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Einsatz & Ergänzung</Link>
-            <Link to="/pricing" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Preise</Link>
-            <Link to="/contact" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Fragen & Feedback</Link>
+            <a href="#product" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Produkt</a>
+            <a href="#why" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Warum OptiSentry</a>
+            <a href="#use-cases" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Einsatz & Ergänzung</a>
+            <a href="#pricing" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Preise</a>
+            <a href="#faq-feedback" className="hidden md:inline-flex px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Fragen & Feedback</a>
             <Button variant="ghost" onClick={() => navigate('/impressum')} className="hidden md:inline-flex">
               Rechtliches
             </Button>

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -122,6 +122,23 @@
     --shadow-lg: 0 10px 15px -3px hsl(214 85% 62% / 0.2), 0 4px 6px -2px hsl(214 85% 62% / 0.1);
     --shadow-glow: 0 0 40px hsl(214 85% 62% / 0.4);
   }
+
+  .light {
+    --background: 210 20% 99%;
+    --foreground: 222 84% 5%;
+    --card: 0 0% 100%;
+    --card-foreground: 222 84% 5%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222 84% 5%;
+    --border: 210 16% 90%;
+    --input: 210 16% 90%;
+    --muted: 210 14% 96%;
+    --muted-foreground: 215 16% 37%;
+    --accent: 210 18% 95%;
+    --accent-foreground: 222 47% 11%;
+    --ring: 214 85% 52%;
+    --gradient-hero: linear-gradient(135deg, hsl(214 92% 56% / 0.08), hsl(214 82% 65% / 0.04));
+  }
 }
 
 @layer base {

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -1,72 +1,229 @@
+import { useState } from 'react'
 import { motion } from 'framer-motion'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { useNavigate } from 'react-router-dom'
 import MarketingLayout from '@/components/marketing-layout'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import KpiLineChart from '@/components/charts/KpiLineChart'
+import KpiBarChart from '@/components/charts/KpiBarChart'
+import KpiDonut from '@/components/charts/KpiDonut'
+import { ArrowRight, ShieldCheck, Repeat, Clock, BarChart3 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
 
 export default function Home() {
-  const navigate = useNavigate()
+  const [chart, setChart] = useState<'identity'|'privacy'|'observability'|null>(null)
   return (
     <MarketingLayout>
-      <section className="py-20 bg-gradient-hero text-center">
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.8 }}>
-          <h1 className="text-4xl md:text-6xl font-bold mb-6">
-            Ihre sichere und <span className="bg-gradient-primary bg-clip-text text-transparent">DSGVO-konforme</span> Lösung
-          </h1>
-          <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-            Passwordless Authentication, vollständige Compliance und Enterprise-Security – alles in einer Plattform.
-          </p>
-          <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
-            <Button size="lg" onClick={() => navigate('/auth/login')}>Kostenlos starten</Button>
-            <Button size="lg" variant="outline" onClick={() => navigate('/product')}>Demo ansehen</Button>
-          </div>
-        </motion.div>
-      </section>
+      <motion.section id="top" className="scroll-mt-24 py-32 text-center bg-[var(--gradient-hero)]" initial={{opacity:0,y:20}} animate={{opacity:1,y:0}} transition={{duration:0.6}}>
+        <h1 className="text-4xl md:text-6xl font-bold mb-6">Ihre sichere und DSGVO-konforme Lösung</h1>
+        <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">Passwordless Authentication, vollständige Compliance und Enterprise-Security – alles in einer Plattform.</p>
+        <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+          <Button size="lg" onClick={() => (window.location.href='/auth/login')}>Kostenlos starten</Button>
+          <Button size="lg" variant="outline" onClick={() => document.getElementById('product')?.scrollIntoView({behavior:'smooth'})}>Demo ansehen</Button>
+        </div>
+      </motion.section>
 
-      <section className="py-20" id="product-teaser">
+      <section id="product" className="scroll-mt-24 py-24">
         <div className="container">
           <h2 className="text-3xl font-bold text-center mb-12">Was macht OptiSentry?</h2>
           <div className="grid gap-6 md:grid-cols-3">
-            <Card className="glass card-hover">
+            <Card onClick={() => setChart('identity')} className="cursor-pointer hover:shadow-lg transition">
               <CardHeader>
                 <CardTitle>Identity &amp; Access</CardTitle>
-                <CardDescription>Passwortlose Anmeldung und RBAC</CardDescription>
+                <CardDescription>Passwortlos (Magic Link, Social), RBAC &amp; Policies, SSO-ready.</CardDescription>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
-                Benutzer können sich passwortlos anmelden – per Magic Link oder Social Login. Rollen und Berechtigungen werden zentral verwaltet.
-              </CardContent>
+              <CardContent className="text-sm text-muted-foreground">Sichere Anmeldung ohne Friktion. Rollen und Sitzungen zentral steuern.</CardContent>
             </Card>
-            <Card className="glass card-hover">
+            <Card onClick={() => setChart('privacy')} className="cursor-pointer hover:shadow-lg transition">
               <CardHeader>
                 <CardTitle>Datenschutz-Workflows</CardTitle>
-                <CardDescription>Automatisierte DSGVO-Prozesse</CardDescription>
+                <CardDescription>DSGVO Requests (Auskunft, Löschung, Berichtigung) mit Fristen &amp; Eskalation, Export.</CardDescription>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
-                Eingebaute Workflows helfen bei Auskunfts- und Löschanfragen. Jeder Schritt wird revisionssicher dokumentiert.
-              </CardContent>
+              <CardContent className="text-sm text-muted-foreground">Geführte Flows statt manueller Kleinarbeit – revisionssicher dokumentiert.</CardContent>
             </Card>
-            <Card className="glass card-hover">
+            <Card onClick={() => setChart('observability')} className="cursor-pointer hover:shadow-lg transition">
               <CardHeader>
                 <CardTitle>Observability</CardTitle>
-                <CardDescription>Audit-Logs &amp; Anomalien-Erkennung</CardDescription>
+                <CardDescription>Audit-Logs, Anomalie-Erkennung, Alerts, Export ins DWH.</CardDescription>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
-                OptiSentry protokolliert alle sicherheitsrelevanten Ereignisse und warnt bei ungewöhnlichen Mustern.
-              </CardContent>
+              <CardContent className="text-sm text-muted-foreground">Jede Veränderung nachvollziehen – in Sekunden auffindbar.</CardContent>
+            </Card>
+          </div>
+          <div className="flex items-center justify-center mt-12 text-sm text-muted-foreground">
+            <span>Login</span><ArrowRight className="mx-2 h-4 w-4" />
+            <span>Policy Check</span><ArrowRight className="mx-2 h-4 w-4" />
+            <span>Audit Log</span><ArrowRight className="mx-2 h-4 w-4" />
+            <span>Action/Webhook</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="why" className="scroll-mt-24 py-24 bg-muted/50">
+        <div className="container grid md:grid-cols-2 gap-8">
+          <div className="flex gap-4">
+            <ShieldCheck className="h-6 w-6" />
+            <div>
+              <h3 className="font-semibold">Governance &amp; Audits</h3>
+              <p className="text-sm text-muted-foreground">Tiefe Protokollierung, klare Nachweise.</p>
+            </div>
+          </div>
+          <div className="flex gap-4">
+            <Repeat className="h-6 w-6" />
+            <div>
+              <h3 className="font-semibold">Automatisierung</h3>
+              <p className="text-sm text-muted-foreground">Weniger manueller Aufwand, mehr Zuverlässigkeit.</p>
+            </div>
+          </div>
+          <div className="flex gap-4">
+            <Clock className="h-6 w-6" />
+            <div>
+              <h3 className="font-semibold">Zeitgewinn</h3>
+              <p className="text-sm text-muted-foreground">Fokus auf Produkt statt Compliance-Bürokratie.</p>
+            </div>
+          </div>
+          <div className="flex gap-4">
+            <BarChart3 className="h-6 w-6" />
+            <div>
+              <h3 className="font-semibold">Skalierbarkeit</h3>
+              <p className="text-sm text-muted-foreground">Wächst mit Nutzerzahl &amp; Anforderungen.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="use-cases" className="scroll-mt-24 py-24">
+        <div className="container">
+          <h2 className="text-3xl font-bold text-center mb-12">Einsatz &amp; Ergänzung</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Startups</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">Compliance ab Tag 1; schnelle Cloud-Implementierung; Templates.</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Enterprise</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">RBAC, Policies, SSO, Mandanten, Reports für interne/externe Audits.</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Agenturen &amp; Partner</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">Mehrere Kund:innen verwalten, White-Label, Reporting.</CardContent>
             </Card>
           </div>
         </div>
       </section>
 
-      <section className="py-20 bg-muted/50">
-        <div className="container text-center">
-          <h2 className="text-3xl font-bold mb-6">Bereit für mehr Sicherheit?</h2>
-          <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
-            <Button size="lg" onClick={() => navigate('/auth/login')}>Free starten</Button>
-            <Button size="lg" variant="outline" onClick={() => navigate('/product')}>Demo ansehen</Button>
+      <section id="pricing" className="scroll-mt-24 py-24 bg-muted/50">
+        <div className="container">
+          <h2 className="text-3xl font-bold text-center mb-12">Preise</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <Card className="p-6 flex flex-col">
+              <CardHeader>
+                <CardTitle>Free</CardTitle>
+                <CardDescription>0 €</CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 text-sm text-muted-foreground space-y-2">
+                <p>Passwordless (1 App)</p>
+                <p>Basic Logs (30 Tage)</p>
+                <p>manuelle DSGVO-Flows</p>
+                <p>Basis-API</p>
+                <p>Community Support</p>
+              </CardContent>
+              <Button onClick={() => (window.location.href='/auth/login')}>Kostenlos starten</Button>
+            </Card>
+            <Card className="p-6 flex flex-col relative border-primary">
+              <Badge className="absolute top-4 right-4" variant="secondary">Beliebt</Badge>
+              <CardHeader>
+                <CardTitle>Pro</CardTitle>
+                <CardDescription>299 €/Monat</CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 text-sm text-muted-foreground space-y-2">
+                <p>Automatisierte DSGVO-Workflows</p>
+                <p>längere Log-Retention (6–12 M)</p>
+                <p>Multi-Project</p>
+                <p>vollständige API/Webhooks/SDKs</p>
+                <p>prior. Support</p>
+              </CardContent>
+              <Button onClick={() => (window.location.href='/auth/login')}>Jetzt upgraden</Button>
+            </Card>
+            <Card className="p-6 flex flex-col">
+              <CardHeader>
+                <CardTitle>Business</CardTitle>
+                <CardDescription>1.499 €/Monat</CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 text-sm text-muted-foreground space-y-2">
+                <p>SSO (SAML/OIDC)</p>
+                <p>Mandanten</p>
+                <p>White-Label</p>
+                <p>Datenresidenz</p>
+                <p>erweiterte Reports</p>
+                <p>24/7 Premium-Support mit SLA</p>
+              </CardContent>
+              <Button asChild variant="outline"><a href="mailto:sales@optisentry.dev?subject=Business%20Anfrage">Kontakt aufnehmen</a></Button>
+            </Card>
           </div>
         </div>
       </section>
+
+      <section id="faq-feedback" className="scroll-mt-24 py-24">
+        <div className="container">
+          <h2 className="text-3xl font-bold text-center mb-12">Fragen &amp; Feedback</h2>
+          <div className="grid md:grid-cols-2 gap-6 mb-8">
+            <Card>
+              <CardHeader>
+                <CardTitle>Brauche ich ein Backend?</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">OptiSentry funktioniert sowohl mit als auch ohne eigenes Backend.</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Wie funktioniert die Demo?</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">Die Demo zeigt einen vordefinierten Flow mit echten Komponenten.</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>DSGVO-Konformität?</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">Alle Prozesse sind revisionssicher dokumentiert und auditierbar.</CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Weitere Fragen?</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">Unser Team hilft gerne weiter.</CardContent>
+            </Card>
+          </div>
+          <Card className="text-center">
+            <CardHeader>
+              <CardTitle>Feedback geben</CardTitle>
+            </CardHeader>
+            <CardContent className="flex justify-center gap-4">
+              <Button variant="outline" asChild><a href="mailto:sales@optisentry.dev?subject=Feedback">E-Mail senden</a></Button>
+              <Button asChild><a href="#product">Produkt ansehen</a></Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <Dialog open={chart!==null} onOpenChange={() => setChart(null)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {chart==='identity' && 'Identity & Access'}
+              {chart==='privacy' && 'Datenschutz-Workflows'}
+              {chart==='observability' && 'Observability'}
+            </DialogTitle>
+          </DialogHeader>
+          {chart==='identity' && <KpiLineChart />}
+          {chart==='privacy' && <KpiBarChart />}
+          {chart==='observability' && <KpiDonut />}
+        </DialogContent>
+      </Dialog>
     </MarketingLayout>
   )
 }


### PR DESCRIPTION
## Summary
- Merge marketing pages into one landing page with feature, pricing, and FAQ sections
- Introduce reusable KPI chart components with demo data and modal display
- Add light theme variables and anchor-based navigation

## Testing
- `npm ci`
- `npm run build`
- `npm run lint` *(fails: Unexpected any, no-empty)*


------
https://chatgpt.com/codex/tasks/task_b_689db9190ed083269916f214c72c1512